### PR TITLE
Add ice cloud layer and `add_cloud` function

### DIFF
--- a/pyLRT/RadTran.py
+++ b/pyLRT/RadTran.py
@@ -166,10 +166,10 @@ class RadTran():
         elif type=="ice":
             cloudstr = '\n'.join([
                 ' {:4.2f} {:2.4f} {:4.2f}'.format(
-                    self.cloud['z'][alt],
-                    self.cloud['iwc'][alt],
-                    self.cloud['re'][alt])
-                for alt in range(len(self.cloud['z']))])
+                    self.ice_cloud['z'][alt],
+                    self.ice_cloud['iwc'][alt],
+                    self.ice_cloud['re'][alt])
+                for alt in range(len(self.ice_cloud['z']))])
             tmpfile.write(cloudstr.encode('ascii'))
             tmpfile.close()
             self.options['ic_file 1D'] = tmpfile.name


### PR DESCRIPTION
- Add `.ice_cloud` property to handle an ice cloud layer, which can be used independently or in addition to a liquid cloud layer
- Add`.add_cloud` function, which adds a liquid or ice cloud layer from a range of options, including conversion from optical depth to cwp
- Increase the number of decimal places which lwc/iwc is stored with when writing the input file to allow thinner clouds

An example of the cloud_spectra example with a multi-layer (ice over liquid) cloud:
![multi-layer-example](https://github.com/EdGrrr/pyLRT/assets/22833757/bd7dfe6e-7ea9-4c8c-b682-0eac17c132dc)
